### PR TITLE
Make Jira skill org-agnostic with private configurations

### DIFF
--- a/ai/skills/jira/SKILL.md
+++ b/ai/skills/jira/SKILL.md
@@ -22,12 +22,25 @@ Natural language interaction with Jira using `acli jira workitem` (Atlassian CLI
 | List my issues | `acli jira workitem search --jql "assignee = currentUser()"` |
 | My in-progress | `acli jira workitem search --jql "assignee = currentUser() AND status = 'In Progress'"` |
 
-**Environment Variables (from `private/jira.sh`):**
+**Environment Variables (values, from `private/jira.sh`):**
 - `$JIRA_PROJECT` — Your project key (e.g., "ID")
 - `$JIRA_SITE` — Your Jira domain (e.g., "my-company.atlassian.net")
 - `$JIRA_USER` — Your email (e.g., "user@my-company.com")
-- `$JIRA_TEAM` — Team UUID for custom field (auto-configured)
 - `$JIRA_LABEL_OPTIONS` — Available labels (comma-separated)
+- Org-specific custom-field values (e.g. `$JIRA_TEAM`) referenced by your private config
+
+---
+
+## Private Configurations
+
+Organization-specific knowledge (required custom fields, special API calls) lives in
+`private/jira/` — git-ignored, never committed. **At the start of any Jira operation,
+check for `private/jira/config.md`; if it exists, read it and apply its required custom
+fields and special calls.** Also check `private/jira/scripts/` for helper scripts. If it
+doesn't exist, just use the generic flow below.
+
+`jira-setup.sh` scaffolds `private/jira/config.md` from
+`references/config-template.md`. See "Working with Custom Fields" to extend it.
 
 ---
 
@@ -83,10 +96,10 @@ Then **only ask for missing required fields**:
    - Convert to `AskUserQuestion` options (max 4 options; include "Other" for custom entry)
    - Extract epic ID from selection
 
-3. **Team (always auto-filled)**:
-   - Team UUID is in `$JIRA_TEAM` (set by `private/jira.sh`)
-   - The script automatically passes this as `customfield_10200`
-   - **Never ask the user**
+3. **Required custom fields (from private config)**:
+   - If `private/jira/config.md` exists, apply each required field it lists as a
+     `--field`/`--field-json` flag (e.g. `--field customfield_10200="$JIRA_TEAM"`)
+   - **Never ask the user** for these — the values come from `private/jira.sh`
 
 4. **Optional fields (only ask if not provided)**:
    - **Description**: If user provided details/criteria, draft a structured description. Otherwise, ask "Would you like to add a description?"
@@ -100,11 +113,11 @@ Then **only ask for missing required fields**:
      --project "$JIRA_PROJECT" \
      --type Story \
      --summary "..." \
-     --parent ID-XXXX \
-     --team "$JIRA_TEAM" \
+     [--parent ID-XXXX] \
      [--assignee email@example.com] \
      [--description "..."] \
-     [--labels "label1,label2"]
+     [--labels "label1,label2"] \
+     [--field customfield_10200="$JIRA_TEAM"]      # required fields from private config
    ```
 
 6. **Execute & verify**: Run the script, then view the created ticket to confirm.
@@ -174,40 +187,24 @@ Ask yourself:
 
 ## Working with Custom Fields
 
-Some Jira instances have custom fields that `acli` doesn't expose as CLI flags. When creating tickets with required custom fields:
+Org-specific custom fields are **not** hardcoded in this skill — they live in
+`private/jira/config.md`. `jira-create-ticket.sh` accepts them generically:
+- `--field KEY=VALUE` — string value (e.g. `--field customfield_10200="$JIRA_TEAM"`)
+- `--field-json KEY=<json>` — object/array/select value (e.g. `--field-json customfield_10010=42`)
 
-1. **Identify the custom field ID**: Fetch an existing ticket via REST API to find the field:
-   ```bash
-   curl -u "$JIRA_USER:$JIRA_API_TOKEN" \
-     "https://$JIRA_SITE/rest/api/2/issue/KEY" | grep customfield
-   ```
+**Discovering and recording a new field.** When a create fails because a field is
+required (or you need its ID), find it from an existing ticket, then add it to the
+private config so future tickets include it automatically:
 
-2. **Get the field value UUID** (if it's a select field):
-   ```bash
-   # Look for the field in the JSON response
-   # Example: "customfield_10200": { "id": "d58100e1-...", "name": "Team Name" }
-   ```
+```bash
+curl -s -u "$JIRA_USER:$JIRA_API_TOKEN" \
+  "https://$JIRA_SITE/rest/api/2/issue/KEY" | grep customfield
+# e.g. "customfield_10200": { "id": "d58100e1-...", "name": "Team Name" } → pass the id string
+```
 
-3. **Use REST API v2 for creation** when custom fields are required:
-   ```bash
-   curl -X POST \
-     -u "$JIRA_USER:$JIRA_API_TOKEN" \
-     -H "Content-Type: application/json" \
-     -d '{
-       "fields": {
-         "project": { "key": "$JIRA_PROJECT" },
-         "summary": "...",
-         "issuetype": { "name": "Task" },
-         "parent": { "key": "ID-XXXX" },
-         "customfield_10200": "team-uuid-here"
-       }
-     }' \
-     "https://$JIRA_SITE/rest/api/2/issue"
-   ```
-
-**Example:**
-- Team field: `customfield_12345`
-- "My Team - Team 1" UUID: `d58100e1-b897-4ed9-963c-9db91a741234`
+**Managing the private config.** Offer to append the discovered field (ID, format, and the
+exact `--field`/`--field-json` flag) to `private/jira/config.md`. If that file doesn't
+exist, run `jira-setup.sh` or copy `references/config-template.md` into `private/jira/`.
 
 ## Safety
 
@@ -246,8 +243,9 @@ This will guide you through:
 1. Installing acli (if needed)
 2. Creating and storing your API token securely
 3. Setting up environment variables in `private/jira.sh`
-4. Authenticating with acli
-5. Verifying your setup
+4. Scaffolding `private/jira/config.md` from the template (org-specific fields)
+5. Authenticating with acli
+6. Verifying your setup
 
 ### Manual Setup
 
@@ -349,7 +347,7 @@ acli jira workitem transition --help
 
 ### 2. **Custom Field Issues (Team, etc.)**
 
-**If you see:** "The Team field is required" or "unknown flag: --team"
+**If you see:** "The X field is required" (e.g. Team) when creating a ticket
 
 **Diagnosis:**
 ```bash
@@ -361,10 +359,9 @@ curl -u "$JIRA_USER:$JIRA_API_TOKEN" \
 ```
 
 **Fix:**
-- Identify the custom field ID (e.g., `customfield_10200`)
-- Find the field's current value and its UUID/ID format
-- Use REST API v2 instead of acli when creating with custom fields
-- Update SKILL.md with the correct field ID and format
+- Identify the custom field ID (e.g., `customfield_10200`) and its UUID/ID format
+- Pass it via `jira-create-ticket.sh --field`/`--field-json`
+- Record it in `private/jira/config.md` (not SKILL.md — it's org-specific)
 
 ### 3. **Parent/Child Hierarchy Issues**
 
@@ -478,3 +475,4 @@ Updated workflow to use REST API v2 for tickets with custom fields.
 
 References:
 - `references/commands.md` - Complete acli command reference
+- `references/config-template.md` - Template for `private/jira/config.md` (org-specific fields)

--- a/ai/skills/jira/SKILL.md
+++ b/ai/skills/jira/SKILL.md
@@ -98,7 +98,7 @@ Then **only ask for missing required fields**:
 
 3. **Required custom fields (from private config)**:
    - If `private/jira/config.md` exists, apply each required field it lists as a
-     `--field`/`--field-json` flag (e.g. `--field customfield_10200="$JIRA_TEAM"`)
+     `--field`/`--field-json` flag (the config gives the exact flags to use)
    - **Never ask the user** for these — the values come from `private/jira.sh`
 
 4. **Optional fields (only ask if not provided)**:
@@ -117,7 +117,7 @@ Then **only ask for missing required fields**:
      [--assignee email@example.com] \
      [--description "..."] \
      [--labels "label1,label2"] \
-     [--field customfield_10200="$JIRA_TEAM"]      # required fields from private config
+     [--field FIELD=VALUE ...]     # required custom fields from private/jira/config.md, if any
    ```
 
 6. **Execute & verify**: Run the script, then view the created ticket to confirm.
@@ -189,8 +189,8 @@ Ask yourself:
 
 Org-specific custom fields are **not** hardcoded in this skill — they live in
 `private/jira/config.md`. `jira-create-ticket.sh` accepts them generically:
-- `--field KEY=VALUE` — string value (e.g. `--field customfield_10200="$JIRA_TEAM"`)
-- `--field-json KEY=<json>` — object/array/select value (e.g. `--field-json customfield_10010=42`)
+- `--field KEY=VALUE` — string value (e.g. `--field customfield_XXXXX="$SOME_VALUE"`)
+- `--field-json KEY=<json>` — object/array/select value (e.g. `--field-json customfield_XXXXX=42`)
 
 **Discovering and recording a new field.** When a create fails because a field is
 required (or you need its ID), find it from an existing ticket, then add it to the
@@ -199,7 +199,7 @@ private config so future tickets include it automatically:
 ```bash
 curl -s -u "$JIRA_USER:$JIRA_API_TOKEN" \
   "https://$JIRA_SITE/rest/api/2/issue/KEY" | grep customfield
-# e.g. "customfield_10200": { "id": "d58100e1-...", "name": "Team Name" } → pass the id string
+# e.g. "customfield_XXXXX": { "id": "d58100e1-...", "name": "..." } → pass the id string
 ```
 
 **Managing the private config.** Offer to append the discovered field (ID, format, and the
@@ -282,8 +282,9 @@ export JIRA_PROJECT="PROJ"
 export JIRA_USER="your@email.com"
 export JIRA_BASE_URL="https://$JIRA_SITE"
 export JIRA_API_TOKEN="$(cat ~/.config/toolbox/jira-token.txt 2>/dev/null)"
-export JIRA_TEAM="team-uuid-here"  # Team UUID from customfield_10200
 export JIRA_EPIC_IDS="ID-100,ID-200"  # Frequently used epic IDs (descriptions fetched dynamically)
+# Org-specific custom-field values go here too, then reference them from private/jira/config.md.
+# Example: export JIRA_TEAM="team-uuid-here"  # used as --field customfield_XXXXX="$JIRA_TEAM"
 ```
 
 Then reload your shell:
@@ -351,7 +352,7 @@ acli jira workitem transition --help
 
 **Diagnosis:**
 ```bash
-# The Team field is likely a custom field, not a standard flag
+# The required field is likely a custom field, not a standard flag
 # Check an existing ticket to find the field ID
 curl -u "$JIRA_USER:$JIRA_API_TOKEN" \
   "https://$JIRA_SITE/rest/api/2/issue/SAMPLE-KEY" | \
@@ -359,7 +360,7 @@ curl -u "$JIRA_USER:$JIRA_API_TOKEN" \
 ```
 
 **Fix:**
-- Identify the custom field ID (e.g., `customfield_10200`) and its UUID/ID format
+- Identify the custom field ID (e.g., `customfield_XXXXX`) and its UUID/ID format
 - Pass it via `jira-create-ticket.sh --field`/`--field-json`
 - Record it in `private/jira/config.md` (not SKILL.md — it's org-specific)
 
@@ -443,12 +444,14 @@ When you discover an issue:
 4. **Update** the relevant section in SKILL.md or references/commands.md
 5. **Document** the fix with a comment explaining why the old instruction was wrong
 
+Note: org-specific custom fields belong in `private/jira/config.md`, not here — only
+commit fixes to generic command syntax/flags.
+
 **Example commit message:**
 ```
-fix: correct custom field handling in jira skill
+fix: correct transition flag in jira skill
 
-Discovered that Team field is customfield_10200 (not a CLI flag).
-Updated workflow to use REST API v2 for tickets with custom fields.
+acli renamed --status to --to-status; updated SKILL.md and references/commands.md.
 ```
 
 ---

--- a/ai/skills/jira/references/commands.md
+++ b/ai/skills/jira/references/commands.md
@@ -98,7 +98,11 @@ acli jira workitem create --project "$JIRA_PROJECT" --from-json "workitem.json"
 # Generate JSON template
 acli jira workitem create --generate-json
 
-# Create via REST API v2 (when custom fields are required)
+# When custom fields are required, prefer the helper script (handles JSON safely):
+#   bash ai/skills/jira/scripts/jira-create-ticket.sh --project "$JIRA_PROJECT" \
+#     --type Task --summary "..." --field customfield_10200="$JIRA_TEAM"
+# Org-specific fields are documented in private/jira/config.md.
+# The raw REST equivalent:
 curl -X POST \
   -u "$JIRA_USER:$JIRA_API_TOKEN" \
   -H "Content-Type: application/json" \

--- a/ai/skills/jira/references/config-template.md
+++ b/ai/skills/jira/references/config-template.md
@@ -1,0 +1,52 @@
+# Jira private configuration
+
+Organization-specific Jira knowledge that should NOT be committed to git.
+Copy this template to `private/jira/config.md` (the `private/` directory is git-ignored)
+and fill it in for your org. `jira-setup.sh` creates it for you automatically.
+
+The Jira skill reads this file at the start of any Jira operation and applies what's here.
+
+---
+
+## Required custom fields
+
+Fields your org requires on every new ticket. The skill passes these to
+`jira-create-ticket.sh` automatically.
+
+Discover a field's ID and shape from an existing ticket:
+
+```bash
+curl -s -u "$JIRA_USER:$JIRA_API_TOKEN" \
+  "https://$JIRA_SITE/rest/api/2/issue/SAMPLE-KEY" | \
+  python3 -c "import json,sys; d=json.load(sys.stdin)['fields']; [print(k,'=',v) for k,v in d.items() if 'custom' in k]"
+```
+
+List each field as a `jira-create-ticket.sh` flag:
+
+- Team (`customfield_10200`, required, string UUID from `$JIRA_TEAM`):
+  `--field customfield_10200="$JIRA_TEAM"`
+
+<!-- Add more fields below. Use --field KEY=VALUE for string values, or
+     --field-json KEY='<json>' for objects/arrays/select fields, e.g.:
+- Sprint (customfield_10010, number):
+  --field-json customfield_10010=42
+-->
+
+## Special API calls
+
+Org-specific calls (custom JQL, non-standard endpoints, bulk operations). Document the
+exact command so the skill can run it.
+
+<!-- Example:
+- "My open bugs" search:
+  acli jira workitem search --jql "assignee = currentUser() AND type = Bug AND status != Done"
+-->
+
+## Helper scripts
+
+Reusable scripts for complex/repeated calls live in `private/jira/scripts/` (git-ignored).
+List them here with a one-line description and how to invoke each.
+
+<!-- Example:
+- `private/jira/scripts/weekly-report.sh` — prints the team's tickets closed this week.
+-->

--- a/ai/skills/jira/scripts/jira-create-ticket.sh
+++ b/ai/skills/jira/scripts/jira-create-ticket.sh
@@ -1,25 +1,37 @@
 #!/usr/bin/env bash
 
-# Create a Jira ticket via REST API v2
-# Handles required custom fields like Team (customfield_10200)
+# Create a Jira ticket via REST API v2.
+#
+# Org-agnostic: standard fields are built-in flags; organization-specific custom
+# fields are passed generically via --field / --field-json (see private/jira/config.md).
 #
 # Usage:
 #   jira-create-ticket.sh \
 #     --project ID \
 #     --type Story \
 #     --summary "Ticket summary" \
-#     --parent ID-1234 \
-#     --team "$JIRA_TEAM" \
+#     [--parent ID-1234] \
 #     [--assignee email@example.com] \
 #     [--description "Multi-line description"] \
-#     [--labels "label1,label2"]
+#     [--labels "label1,label2"] \
+#     [--field customfield_10200=team-uuid] \
+#     [--field-json customfield_99999='{"value":"x"}']
+#
+# --field KEY=VALUE        Custom field with a string value: "KEY": "VALUE"
+# --field-json KEY=<json>  Custom field with a raw JSON value: "KEY": <json>
+#                          (objects, arrays, select fields). Both flags repeatable.
+#
+# Set DRY_RUN=1 to print the request JSON instead of submitting it.
 
 set -euo pipefail
 
 # Default values
+PARENT=""
 ASSIGNEE=""
 DESCRIPTION=""
 LABELS=""
+FIELD_STR=()
+FIELD_JSON=()
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -28,18 +40,19 @@ while [[ $# -gt 0 ]]; do
     --type) TYPE="$2"; shift 2 ;;
     --summary) SUMMARY="$2"; shift 2 ;;
     --parent) PARENT="$2"; shift 2 ;;
-    --team) TEAM="$2"; shift 2 ;;
     --assignee) ASSIGNEE="$2"; shift 2 ;;
     --description) DESCRIPTION="$2"; shift 2 ;;
     --labels) LABELS="$2"; shift 2 ;;
+    --field) FIELD_STR+=("$2"); shift 2 ;;
+    --field-json) FIELD_JSON+=("$2"); shift 2 ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
 
 # Validate required fields
-if [[ -z "${PROJECT:-}" ]] || [[ -z "${TYPE:-}" ]] || [[ -z "${SUMMARY:-}" ]] || [[ -z "${PARENT:-}" ]] || [[ -z "${TEAM:-}" ]]; then
+if [[ -z "${PROJECT:-}" ]] || [[ -z "${TYPE:-}" ]] || [[ -z "${SUMMARY:-}" ]]; then
   echo "Error: Missing required fields"
-  echo "Required: --project, --type, --summary, --parent, --team"
+  echo "Required: --project, --type, --summary"
   exit 1
 fi
 
@@ -50,41 +63,63 @@ if [[ -z "${JIRA_SITE:-}" ]] || [[ -z "${JIRA_USER:-}" ]] || [[ -z "${JIRA_API_T
   exit 1
 fi
 
-# Build the request JSON
-REQUEST=$(cat <<EOF
-{
-  "fields": {
-    "project": { "key": "$PROJECT" },
-    "summary": "$SUMMARY",
-    "issuetype": { "name": "$TYPE" },
-    "parent": { "key": "$PARENT" },
-    "customfield_10200": "$TEAM"
-EOF
-)
+# Build the fields object with jq (safe escaping for arbitrary values)
+FIELDS=$(jq -n \
+  --arg project "$PROJECT" \
+  --arg summary "$SUMMARY" \
+  --arg type "$TYPE" \
+  '{project: {key: $project}, summary: $summary, issuetype: {name: $type}}')
 
-# Add optional description
+if [[ -n "$PARENT" ]]; then
+  FIELDS=$(jq --arg p "$PARENT" '. + {parent: {key: $p}}' <<<"$FIELDS")
+fi
+
 if [[ -n "$DESCRIPTION" ]]; then
-  REQUEST+=",
-    \"description\": $(printf '%s\n' "$DESCRIPTION" | jq -Rs .)"
+  FIELDS=$(jq --arg d "$DESCRIPTION" '. + {description: $d}' <<<"$FIELDS")
 fi
 
-# Add optional assignee
 if [[ -n "$ASSIGNEE" ]]; then
-  REQUEST+=",
-    \"assignee\": { \"name\": \"$ASSIGNEE\" }"
+  FIELDS=$(jq --arg a "$ASSIGNEE" '. + {assignee: {name: $a}}' <<<"$FIELDS")
 fi
 
-# Add optional labels
 if [[ -n "$LABELS" ]]; then
-  # Convert comma-separated string to JSON array
-  LABELS_JSON=$(echo "$LABELS" | tr ',' '\n' | jq -R . | jq -s .)
-  REQUEST+=",
-    \"labels\": $LABELS_JSON"
+  LABELS_JSON=$(tr ',' '\n' <<<"$LABELS" | jq -R . | jq -s .)
+  FIELDS=$(jq --argjson l "$LABELS_JSON" '. + {labels: $l}' <<<"$FIELDS")
 fi
 
-REQUEST+="
-  }
-}"
+# Custom string-valued fields (--field KEY=VALUE)
+for pair in "${FIELD_STR[@]+"${FIELD_STR[@]}"}"; do
+  key="${pair%%=*}"
+  val="${pair#*=}"
+  if [[ -z "$key" || "$key" == "$pair" ]]; then
+    echo "Error: --field expects KEY=VALUE, got: $pair"
+    exit 1
+  fi
+  FIELDS=$(jq --arg k "$key" --arg v "$val" '. + {($k): $v}' <<<"$FIELDS")
+done
+
+# Custom raw-JSON fields (--field-json KEY=<json>)
+for pair in "${FIELD_JSON[@]+"${FIELD_JSON[@]}"}"; do
+  key="${pair%%=*}"
+  val="${pair#*=}"
+  if [[ -z "$key" || "$key" == "$pair" ]]; then
+    echo "Error: --field-json expects KEY=<json>, got: $pair"
+    exit 1
+  fi
+  if ! jq -e . >/dev/null 2>&1 <<<"$val"; then
+    echo "Error: --field-json value for $key is not valid JSON: $val"
+    exit 1
+  fi
+  FIELDS=$(jq --arg k "$key" --argjson v "$val" '. + {($k): $v}' <<<"$FIELDS")
+done
+
+REQUEST=$(jq -n --argjson f "$FIELDS" '{fields: $f}')
+
+# Dry run: print the request and exit
+if [[ "${DRY_RUN:-}" == "1" ]]; then
+  echo "$REQUEST"
+  exit 0
+fi
 
 # Submit the request
 RESPONSE=$(curl -s -X POST \

--- a/ai/skills/jira/scripts/jira-setup.sh
+++ b/ai/skills/jira/scripts/jira-setup.sh
@@ -299,6 +299,18 @@ EOF
 chmod 600 "$private_dir/jira.sh"
 echo "✓ Created $private_dir/jira.sh"
 
+# Scaffold the private org-config (git-ignored) from the committed template.
+# Holds org-specific custom fields and special API calls; the Jira skill reads it.
+jira_config_dir="$private_dir/jira"
+config_template="$TOOLBOX_ROOT/ai/skills/jira/references/config-template.md"
+if [[ -f "$jira_config_dir/config.md" ]]; then
+  echo "✓ Private config already exists: $jira_config_dir/config.md (left unchanged)"
+elif [[ -f "$config_template" ]]; then
+  mkdir -p "$jira_config_dir/scripts"
+  cp "$config_template" "$jira_config_dir/config.md"
+  echo "✓ Created $jira_config_dir/config.md (from template) — edit it to add org-specific fields"
+fi
+
 echo ""
 echo "─────────────────────────────────────────"
 echo ""

--- a/private/README.md
+++ b/private/README.md
@@ -37,6 +37,20 @@ gwip() {
 
 After creating the file, run `refresh` and your commands will be available!
 
+## Skill configurations
+
+Skills can keep **organization-specific** configuration here too, in a per-skill
+subdirectory (e.g. `private/jira/`). This is for knowledge that should never be committed
+to the shared repo — required custom fields, special API calls, internal endpoints.
+
+Convention:
+
+- `private/<skill>/config.md` — markdown the skill reads at runtime and applies
+- `private/<skill>/scripts/` — helper scripts for complex/repeated calls
+
+For Jira, run `bash ai/skills/jira/scripts/jira-setup.sh` to scaffold `private/jira/config.md`
+from `ai/skills/jira/references/config-template.md`, or copy that template by hand.
+
 ## Tips
 
 - Use descriptive function names to avoid conflicts

--- a/scripts/jira-create-ticket.sh
+++ b/scripts/jira-create-ticket.sh
@@ -1,25 +1,37 @@
 #!/usr/bin/env bash
 
-# Create a Jira ticket via REST API v2
-# Handles required custom fields like Team (customfield_10200)
+# Create a Jira ticket via REST API v2.
+#
+# Org-agnostic: standard fields are built-in flags; organization-specific custom
+# fields are passed generically via --field / --field-json (see private/jira/config.md).
 #
 # Usage:
 #   jira-create-ticket.sh \
 #     --project ID \
 #     --type Story \
 #     --summary "Ticket summary" \
-#     --parent ID-1234 \
-#     --team "$JIRA_TEAM" \
+#     [--parent ID-1234] \
 #     [--assignee email@example.com] \
 #     [--description "Multi-line description"] \
-#     [--labels "label1,label2"]
+#     [--labels "label1,label2"] \
+#     [--field customfield_10200=team-uuid] \
+#     [--field-json customfield_99999='{"value":"x"}']
+#
+# --field KEY=VALUE        Custom field with a string value: "KEY": "VALUE"
+# --field-json KEY=<json>  Custom field with a raw JSON value: "KEY": <json>
+#                          (objects, arrays, select fields). Both flags repeatable.
+#
+# Set DRY_RUN=1 to print the request JSON instead of submitting it.
 
 set -euo pipefail
 
 # Default values
+PARENT=""
 ASSIGNEE=""
 DESCRIPTION=""
 LABELS=""
+FIELD_STR=()
+FIELD_JSON=()
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -28,18 +40,19 @@ while [[ $# -gt 0 ]]; do
     --type) TYPE="$2"; shift 2 ;;
     --summary) SUMMARY="$2"; shift 2 ;;
     --parent) PARENT="$2"; shift 2 ;;
-    --team) TEAM="$2"; shift 2 ;;
     --assignee) ASSIGNEE="$2"; shift 2 ;;
     --description) DESCRIPTION="$2"; shift 2 ;;
     --labels) LABELS="$2"; shift 2 ;;
+    --field) FIELD_STR+=("$2"); shift 2 ;;
+    --field-json) FIELD_JSON+=("$2"); shift 2 ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
 
 # Validate required fields
-if [[ -z "${PROJECT:-}" ]] || [[ -z "${TYPE:-}" ]] || [[ -z "${SUMMARY:-}" ]] || [[ -z "${PARENT:-}" ]] || [[ -z "${TEAM:-}" ]]; then
+if [[ -z "${PROJECT:-}" ]] || [[ -z "${TYPE:-}" ]] || [[ -z "${SUMMARY:-}" ]]; then
   echo "Error: Missing required fields"
-  echo "Required: --project, --type, --summary, --parent, --team"
+  echo "Required: --project, --type, --summary"
   exit 1
 fi
 
@@ -50,41 +63,63 @@ if [[ -z "${JIRA_SITE:-}" ]] || [[ -z "${JIRA_USER:-}" ]] || [[ -z "${JIRA_API_T
   exit 1
 fi
 
-# Build the request JSON
-REQUEST=$(cat <<EOF
-{
-  "fields": {
-    "project": { "key": "$PROJECT" },
-    "summary": "$SUMMARY",
-    "issuetype": { "name": "$TYPE" },
-    "parent": { "key": "$PARENT" },
-    "customfield_10200": "$TEAM"
-EOF
-)
+# Build the fields object with jq (safe escaping for arbitrary values)
+FIELDS=$(jq -n \
+  --arg project "$PROJECT" \
+  --arg summary "$SUMMARY" \
+  --arg type "$TYPE" \
+  '{project: {key: $project}, summary: $summary, issuetype: {name: $type}}')
 
-# Add optional description
+if [[ -n "$PARENT" ]]; then
+  FIELDS=$(jq --arg p "$PARENT" '. + {parent: {key: $p}}' <<<"$FIELDS")
+fi
+
 if [[ -n "$DESCRIPTION" ]]; then
-  REQUEST+=",
-    \"description\": $(printf '%s\n' "$DESCRIPTION" | jq -Rs .)"
+  FIELDS=$(jq --arg d "$DESCRIPTION" '. + {description: $d}' <<<"$FIELDS")
 fi
 
-# Add optional assignee
 if [[ -n "$ASSIGNEE" ]]; then
-  REQUEST+=",
-    \"assignee\": { \"name\": \"$ASSIGNEE\" }"
+  FIELDS=$(jq --arg a "$ASSIGNEE" '. + {assignee: {name: $a}}' <<<"$FIELDS")
 fi
 
-# Add optional labels
 if [[ -n "$LABELS" ]]; then
-  # Convert comma-separated string to JSON array
-  LABELS_JSON=$(echo "$LABELS" | tr ',' '\n' | jq -R . | jq -s .)
-  REQUEST+=",
-    \"labels\": $LABELS_JSON"
+  LABELS_JSON=$(tr ',' '\n' <<<"$LABELS" | jq -R . | jq -s .)
+  FIELDS=$(jq --argjson l "$LABELS_JSON" '. + {labels: $l}' <<<"$FIELDS")
 fi
 
-REQUEST+="
-  }
-}"
+# Custom string-valued fields (--field KEY=VALUE)
+for pair in "${FIELD_STR[@]+"${FIELD_STR[@]}"}"; do
+  key="${pair%%=*}"
+  val="${pair#*=}"
+  if [[ -z "$key" || "$key" == "$pair" ]]; then
+    echo "Error: --field expects KEY=VALUE, got: $pair"
+    exit 1
+  fi
+  FIELDS=$(jq --arg k "$key" --arg v "$val" '. + {($k): $v}' <<<"$FIELDS")
+done
+
+# Custom raw-JSON fields (--field-json KEY=<json>)
+for pair in "${FIELD_JSON[@]+"${FIELD_JSON[@]}"}"; do
+  key="${pair%%=*}"
+  val="${pair#*=}"
+  if [[ -z "$key" || "$key" == "$pair" ]]; then
+    echo "Error: --field-json expects KEY=<json>, got: $pair"
+    exit 1
+  fi
+  if ! jq -e . >/dev/null 2>&1 <<<"$val"; then
+    echo "Error: --field-json value for $key is not valid JSON: $val"
+    exit 1
+  fi
+  FIELDS=$(jq --arg k "$key" --argjson v "$val" '. + {($k): $v}' <<<"$FIELDS")
+done
+
+REQUEST=$(jq -n --argjson f "$FIELDS" '{fields: $f}')
+
+# Dry run: print the request and exit
+if [[ "${DRY_RUN:-}" == "1" ]]; then
+  echo "$REQUEST"
+  exit 0
+fi
 
 # Submit the request
 RESPONSE=$(curl -s -X POST \

--- a/scripts/jira-setup.sh
+++ b/scripts/jira-setup.sh
@@ -299,6 +299,18 @@ EOF
 chmod 600 "$private_dir/jira.sh"
 echo "✓ Created $private_dir/jira.sh"
 
+# Scaffold the private org-config (git-ignored) from the committed template.
+# Holds org-specific custom fields and special API calls; the Jira skill reads it.
+jira_config_dir="$private_dir/jira"
+config_template="$TOOLBOX_ROOT/ai/skills/jira/references/config-template.md"
+if [[ -f "$jira_config_dir/config.md" ]]; then
+  echo "✓ Private config already exists: $jira_config_dir/config.md (left unchanged)"
+elif [[ -f "$config_template" ]]; then
+  mkdir -p "$jira_config_dir/scripts"
+  cp "$config_template" "$jira_config_dir/config.md"
+  echo "✓ Created $jira_config_dir/config.md (from template) — edit it to add org-specific fields"
+fi
+
 echo ""
 echo "─────────────────────────────────────────"
 echo ""


### PR DESCRIPTION
Move organization-specific Jira knowledge (required custom fields, special
API calls) out of the committed skill into a git-ignored private/jira/
configuration that the skill loads at runtime.

- Generalize jira-create-ticket.sh: drop the hardcoded Team customfield /
  required --team flag, make --parent optional, and add repeatable
  --field KEY=VALUE and --field-json KEY=<json> flags (JSON built with jq).
- Add references/config-template.md as the canonical starter for
  private/jira/config.md, scaffolded by jira-setup.sh into private/jira/
  (with a scripts/ subdir) without clobbering an existing config.
- SKILL.md: add a Private Configurations section, apply required custom
  fields from the private config, and document discovering/recording new
  fields there instead of in the shared skill.
- private/README.md: document the per-skill private config convention.

https://claude.ai/code/session_011oNkFj425sPYggbKSCg4um